### PR TITLE
S-005: Session Prometheus metrics

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -42,7 +42,7 @@
 - [x] S-002: ToolExecutor и ToolContext (per-session) (PR #52)
 - [x] S-003: Per-session rate limiting (token bucket) (PR #53)
 - [x] S-004: MCP tool `session_info` — клиент может запросить своё состояние (rate limit remaining, TTL, idle timeout) (PR #66)
-- [ ] S-005: Session metrics — Prometheus gauges для активных сессий, duration histogram, idle timer
+- [x] S-005: Session metrics — Prometheus gauges для активных сессий, duration histogram, idle timer (PR #67)
 - [x] MW-001: Middleware pipeline для tool calls (pre/post hooks, logging, error handling) (PR #55)
 - [x] MW-002: Internal event bus (pub/sub внутри сервера) (PR #57)
 - [x] MW-003: Built-in logging middleware (request/response через MW-001) (PR #59)
@@ -223,7 +223,7 @@ SK-001 (Skills CRUD) → WF-001 (Workflow DAG) → WF-002 (Executor)
 | S-002 | ToolExecutor и ToolContext (per-session) | medium | **done** ✅ | 2.2 | S-001 |
 | S-003 | Per-session rate limiting (token bucket) | medium | **done** ✅ | 2.3 | S-001 |
 | S-004 | MCP tool `session_info`: клиент запрашивает своё состояние — rate limit remaining, TTL, idle timeout, session age | medium | **done** | — | S-001, S-003, S-002 |
-| S-005 | Session Prometheus metrics: gauges `mcp_sessions_active`, `mcp_sessions_total`, histogram `mcp_session_duration_seconds`, `mcp_session_idle_seconds`. Обновление через SessionManager callbacks | low | pending | — | S-001, F-005 |
+| S-005 | Session Prometheus metrics: gauges `mcp_sessions_active`, `mcp_sessions_total`, histogram `mcp_session_duration_seconds`, `mcp_session_idle_seconds` | low | **done** | — | S-001, F-005 |
 
 ---
 
@@ -521,6 +521,7 @@ SK-001 (Skills CRUD) → WF-001 (Workflow DAG) → WF-002 (Executor)
 | ID | Задача | Закрыто | PR |
 |----|--------|---------|-----|
 | S-004 | session_info + session_list MCP tools (13 tests) | 2026-04-08 | #66 |
+| S-005 | Session Prometheus metrics (gauges, histograms, callbacks, 17 tests) | 2026-04-08 | #67 |
 | ACL-002 | Фильтрация списков инструментов/ресурсов по ACL (filterToolNames, filterResourceUris, 29 tests) | 2026-04-08 | #65 |
 | ACL-003 | Проверка авторизации при вызове инструментов (middleware integration, 4 tests) | 2026-04-08 | #65 |
 | ACL-001 | ACL model and policy definitions (ACLEngine, middleware, pre-hook, 51 tests) | 2026-04-08 | #64 |
@@ -565,7 +566,7 @@ SK-001 (Skills CRUD) → WF-001 (Workflow DAG) → WF-002 (Executor)
 | Foundation (0) | 6 | 0 | 0 | 6 | 0 | 0 |
 | Transport (1) | 4 | 1 | 0 | 3 | 0 | 0 |
 | Middleware & Infra | 4 | 1 | 0 | 3 | 0 | 0 |
-| Sessions (2) | 5 | 1 | 0 | 4 | 0 | 0 |
+| Sessions (2) | 5 | 0 | 0 | 5 | 0 | 0 |
 | Auth (3) | 3 | 0 | 0 | 3 | 0 | 0 |
 | ACL (4) | 3 | 0 | 0 | 3 | 0 | 0 |
 | Proxy (5) | 4 | 4 | 0 | 0 | 0 | 0 |
@@ -584,4 +585,4 @@ SK-001 (Skills CRUD) → WF-001 (Workflow DAG) → WF-002 (Executor)
 | Memory (D) | 4 | 4 | 0 | 0 | 0 | 0 |
 | Integration Hub (E) | 6 | 6 | 0 | 0 | 0 | 0 |
 | Web UI (13) | 7 | 7 | 0 | 0 | 0 | 0 |
-| **Итого** | **139** | **104** | **0** | **45** | **0** | **1** |
+| **Итого** | **139** | **103** | **0** | **46** | **0** | **1** |

--- a/src/core/app-container.ts
+++ b/src/core/app-container.ts
@@ -31,7 +31,7 @@ import type { ServerContext } from '../register/context.js';
 import type { TransportAdapter, TransportConfig } from '../transport/types.js';
 import { defaultTransportRegistry } from '../transport/index.js';
 import { createLogger, childLogger } from './logger.js';
-import { initMetrics, updateServerInfo } from './metrics.js';
+import { initMetrics, updateServerInfo, recordSessionCreated, recordSessionClosed } from './metrics.js';
 import { SessionManager } from './session-manager.js';
 import type { SessionManagerOptions } from './session-manager.js';
 import { EventBus } from './event-bus.js';
@@ -261,9 +261,12 @@ export class AppContainer {
 
       // 6. SessionManager for multi-client transports (auto for non-stdio, unless explicitly disabled)
       if (this.opts.sessionManager !== false && this.opts.transportType !== 'stdio') {
-        this.sessionMgr = new SessionManager(
-          this.opts.sessionManager === undefined ? undefined : this.opts.sessionManager,
-        );
+        this.sessionMgr = new SessionManager({
+          ...(this.opts.sessionManager === undefined ? {} : this.opts.sessionManager),
+          // S-005: wire session metrics callbacks
+          onSessionCreate: () => recordSessionCreated(),
+          onSessionClose: (durationMs, idleMs, reason) => recordSessionClosed(durationMs, idleMs, reason),
+        });
         this.sessionMgr.startPrune();
         this.addCleanup(() => this.sessionMgr!.closeAll());
         this.log.info('session manager initialized');

--- a/src/core/metrics.ts
+++ b/src/core/metrics.ts
@@ -1,5 +1,5 @@
 /**
- * Prometheus metrics module (F-005)
+ * Prometheus metrics module (F-005, S-005)
  *
  * Exports a /metrics endpoint compatible with Prometheus scraping.
  * Tracks:
@@ -7,6 +7,10 @@
  *   - mcp_tool_call_duration_seconds — histogram per tool name
  *   - mcp_resource_reads_total — counter per resource URI prefix
  *   - mcp_server_info — gauge with version, uptime, transport, tool count
+ *   - mcp_sessions_total — counter per status (opened/closed/expired/idle_timeout) (S-005)
+ *   - mcp_sessions_active — gauge: current active sessions (S-005)
+ *   - mcp_session_duration_seconds — histogram: session lifetime (S-005)
+ *   - mcp_session_idle_seconds — histogram: idle time before close per reason (S-005)
  *
  * Enable/disable via METRICS_ENABLED env var (default: true for http, false for stdio).
  */
@@ -19,12 +23,16 @@ let _registry: Registry | undefined;
 let _counters: {
   toolCalls: Counter<string>;
   resourceReads: Counter<string>;
+  sessionsTotal: Counter<string>;
 } | undefined;
 let _histograms: {
   toolDuration: Histogram<string>;
+  sessionDuration: Histogram<string>;
+  sessionIdle: Histogram<string>;
 } | undefined;
 let _gauges: {
   serverInfo: Gauge<string>;
+  sessionsActive: Gauge<string>;
 } | undefined;
 
 /**
@@ -80,6 +88,13 @@ export function initMetrics(opts?: { version?: string; defaultMetrics?: boolean 
       labelNames: ['uri_prefix', 'status'] as const,
       registers: [_registry],
     }),
+    // S-005: session counter
+    sessionsTotal: new Counter({
+      name: 'mcp_sessions_total',
+      help: 'Total MCP sessions',
+      labelNames: ['status'] as const,
+      registers: [_registry],
+    }),
   };
 
   // mcp_tool_call_duration_seconds{tool="name"}
@@ -91,6 +106,22 @@ export function initMetrics(opts?: { version?: string; defaultMetrics?: boolean 
       buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
       registers: [_registry],
     }),
+    // S-005: session duration histogram
+    sessionDuration: new Histogram({
+      name: 'mcp_session_duration_seconds',
+      help: 'MCP session duration in seconds',
+      labelNames: [] as const,
+      buckets: [1, 10, 60, 300, 600, 1800, 3600, 7200, 14400, 28800, 86400],
+      registers: [_registry],
+    }),
+    // S-005: session idle time histogram before close
+    sessionIdle: new Histogram({
+      name: 'mcp_session_idle_seconds',
+      help: 'MCP session idle time before close in seconds',
+      labelNames: ['reason'] as const,
+      buckets: [1, 10, 60, 300, 600, 1800, 3600],
+      registers: [_registry],
+    }),
   };
 
   // mcp_server_info{version="...",transport="..."} = 1 (uptime via process_start_time_seconds from default metrics)
@@ -99,6 +130,12 @@ export function initMetrics(opts?: { version?: string; defaultMetrics?: boolean 
       name: 'mcp_server_info',
       help: 'MCP server metadata (always 1)',
       labelNames: ['version', 'transport', 'tools_registered'] as const,
+      registers: [_registry],
+    }),
+    // S-005: active sessions gauge
+    sessionsActive: new Gauge({
+      name: 'mcp_sessions_active',
+      help: 'Current number of active MCP sessions',
       registers: [_registry],
     }),
   };
@@ -148,6 +185,47 @@ export function updateServerInfo(opts: { version?: string; toolCount?: number })
     { version, transport, tools_registered: String(opts.toolCount ?? 0) },
     1,
   );
+}
+
+/**
+ * Record session creation (S-005).
+ * Increments sessions_total{status="opened"} and sessions_active gauge.
+ */
+export function recordSessionCreated(): void {
+  if (!_counters || !_gauges) return;
+  _counters.sessionsTotal.labels({ status: 'opened' }).inc();
+  _gauges.sessionsActive.inc();
+}
+
+/**
+ * Record session close (S-005).
+ * Increments sessions_total with reason label, decrements sessions_active,
+ * records duration and idle histograms.
+ *
+ * @param durationMs — session lifetime in milliseconds
+ * @param idleMs — idle time at close in milliseconds
+ * @param reason — close reason: 'manual' | 'expired' | 'idle_timeout'
+ */
+export function recordSessionClosed(
+  durationMs: number,
+  idleMs: number,
+  reason: 'manual' | 'expired' | 'idle_timeout',
+): void {
+  if (!_counters || !_gauges || !_histograms) return;
+  const counterStatus = reason === 'idle_timeout' ? 'idle_timeout' : reason === 'expired' ? 'expired' : 'closed';
+  _counters.sessionsTotal.labels({ status: counterStatus }).inc();
+  _gauges.sessionsActive.dec();
+  _histograms.sessionDuration.observe(durationMs / 1000);
+  _histograms.sessionIdle.labels({ reason }).observe(idleMs / 1000);
+}
+
+/**
+ * Set active sessions gauge to exact value (S-005).
+ * Useful for sync/correction if gauge drifts.
+ */
+export function setSessionsActive(count: number): void {
+  if (!_gauges) return;
+  _gauges.sessionsActive.set(count);
 }
 
 /**

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -79,6 +79,9 @@ export interface CreateSessionOptions {
   onClose?: (sessionId: string) => void | Promise<void>;
 }
 
+/** Close reason for session metrics (S-005). */
+export type SessionCloseReason = 'manual' | 'expired' | 'idle_timeout';
+
 /** Configuration for SessionManager. */
 export interface SessionManagerOptions {
   /** Maximum concurrent sessions. Default: 1000. */
@@ -89,6 +92,18 @@ export interface SessionManagerOptions {
   idleTimeoutMs?: number;
   /** Interval between prune sweeps in milliseconds. Default: 60000 (1min). */
   pruneIntervalMs?: number;
+  /**
+   * Callback invoked when a new session is created (S-005).
+   * Used for metrics instrumentation.
+   */
+  onSessionCreate?: () => void;
+  /**
+   * Callback invoked when a session is closed (S-005).
+   * @param durationMs — session lifetime in milliseconds
+   * @param idleMs — idle time at close in milliseconds
+   * @param reason — close reason
+   */
+  onSessionClose?: (durationMs: number, idleMs: number, reason: SessionCloseReason) => void;
 }
 
 // ─── Internal session ────────────────────────────────────────────────
@@ -113,9 +128,11 @@ export class SessionManager {
   private readonly ttlMs: number;
   private readonly idleMs: number;
   private readonly pruneMs: number;
+  private readonly options: SessionManagerOptions | undefined;
   private _closed = false;
 
   constructor(options?: SessionManagerOptions) {
+    this.options = options;
     this.maxSessions = options?.maxSessions
       ?? parseInt(process.env.MCP_MAX_SESSIONS || '1000', 10);
     this.ttlMs = options?.sessionTtlMs
@@ -169,6 +186,9 @@ export class SessionManager {
     this.sessions.set(id, session);
     log.info({ sessionId: id, remote: opts.remote, total: this.sessions.size }, 'session created');
 
+    // S-005: notify metrics
+    this.options?.onSessionCreate?.();
+
     return this.toInfo(session);
   }
 
@@ -187,11 +207,17 @@ export class SessionManager {
   /**
    * Close a specific session by ID.
    * Calls the onClose callback if provided.
+   * @param sessionId — session to close
+   * @param reason — close reason for metrics (default: 'manual')
    * @returns true if session existed and was closed, false otherwise.
    */
-  async close(sessionId: string): Promise<boolean> {
+  async close(sessionId: string, reason?: SessionCloseReason): Promise<boolean> {
+    const closeReason: SessionCloseReason = reason ?? 'manual';
     const session = this.sessions.get(sessionId);
     if (!session) return false;
+
+    const duration = Date.now() - session.createdAt;
+    const idle = Date.now() - session.lastActivityAt;
 
     this.sessions.delete(sessionId);
 
@@ -204,8 +230,10 @@ export class SessionManager {
       }
     }
 
-    const duration = Date.now() - session.createdAt;
-    log.info({ sessionId, remote: session.remote, durationMs: duration }, 'session closed');
+    // S-005: notify metrics
+    this.options?.onSessionClose?.(duration, idle, closeReason);
+
+    log.info({ sessionId, remote: session.remote, durationMs: duration, reason: closeReason }, 'session closed');
 
     return true;
   }
@@ -285,13 +313,13 @@ export class SessionManager {
    */
   async prune(): Promise<string[]> {
     const now = Date.now();
-    const expired: string[] = [];
+    const expired: Array<{ id: string; reason: SessionCloseReason }> = [];
 
     for (const [id, session] of this.sessions) {
       // Check per-session expiry first (A-003)
       if (session.expiresAt != null && now >= session.expiresAt) {
         log.info({ sessionId: id, expiresAt: session.expiresAt, reason: 'token-expiry' }, 'session expired (token TTL)');
-        expired.push(id);
+        expired.push({ id, reason: 'expired' as const });
  } else {
         // Fall back to global TTL + idle checks
         const age = now - session.createdAt;
@@ -299,24 +327,26 @@ export class SessionManager {
 
         if (age >= this.ttlMs) {
           log.info({ sessionId: id, ageMs: age, ttlMs: this.ttlMs }, 'session TTL expired');
-          expired.push(id);
+          expired.push({ id, reason: 'expired' as const });
         } else if (idle >= this.idleMs) {
           log.info({ sessionId: id, idleMs: idle, idleTimeoutMs: this.idleMs }, 'session idle timeout');
-          expired.push(id);
+          expired.push({ id, reason: 'idle_timeout' as const });
         }
       }
     }
 
-    // Close all expired sessions
-    for (const id of expired) {
-      await this.close(id);
+    // Close all expired sessions with their reasons
+    const closedIds: string[] = [];
+    for (const { id, reason } of expired) {
+      await this.close(id, reason);
+      closedIds.push(id);
     }
 
-    if (expired.length > 0) {
-      log.info({ closed: expired.length, remaining: this.sessions.size }, 'prune sweep completed');
+    if (closedIds.length > 0) {
+      log.info({ closed: closedIds.length, remaining: this.sessions.size }, 'prune sweep completed');
     }
 
-    return expired;
+    return closedIds;
   }
 
   // ─── Per-session TTL (A-003) ────────────────────────────────────

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { initMetrics, getMetricsRegistry, recordToolCall, recordResourceRead, updateServerInfo, createMetricsHandler, wrapToolHandler, _resetMetrics } from '../src/core/metrics.js';
+import { initMetrics, getMetricsRegistry, recordToolCall, recordResourceRead, updateServerInfo, createMetricsHandler, wrapToolHandler, recordSessionCreated, recordSessionClosed, setSessionsActive, _resetMetrics } from '../src/core/metrics.js';
 
 describe('core/metrics', () => {
   beforeEach(() => {
@@ -203,6 +203,158 @@ describe('core/metrics', () => {
 
       const result = await wrapped({ x: 5 });
       expect(result).toEqual({ result: 10 });
+    });
+  });
+
+  // ─── S-005: Session metrics ───────────────────────────────────────
+
+  describe('recordSessionCreated (S-005)', () => {
+    it('does not throw when metrics are disabled', () => {
+      process.env.MCP_TRANSPORT = 'stdio';
+      initMetrics();
+      expect(() => recordSessionCreated()).not.toThrow();
+    });
+
+    it('increments sessions_total{status="opened"} and sessions_active gauge', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      recordSessionCreated();
+      recordSessionCreated();
+      recordSessionCreated();
+
+      const metrics = await reg.metrics();
+      expect(metrics).toContain('mcp_sessions_total{status="opened"} 3');
+      expect(metrics).toContain('mcp_sessions_active 3');
+    });
+  });
+
+  describe('recordSessionClosed (S-005)', () => {
+    it('does not throw when metrics are disabled', () => {
+      process.env.MCP_TRANSPORT = 'stdio';
+      initMetrics();
+      expect(() => recordSessionClosed(5000, 1000, 'manual')).not.toThrow();
+      expect(() => recordSessionClosed(3000, 500, 'expired')).not.toThrow();
+      expect(() => recordSessionClosed(2000, 2000, 'idle_timeout')).not.toThrow();
+    });
+
+    it('decrements sessions_active and records counter + histograms for manual close', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      // Create 3 sessions then close 1
+      recordSessionCreated();
+      recordSessionCreated();
+      recordSessionCreated();
+      recordSessionClosed(60_000, 5_000, 'manual');
+
+      const metrics = await reg.metrics();
+      // Counter: 3 opened + 1 closed
+      expect(metrics).toContain('mcp_sessions_total{status="opened"} 3');
+      expect(metrics).toContain('mcp_sessions_total{status="closed"} 1');
+      // Gauge: 3 created - 1 closed = 2
+      expect(metrics).toContain('mcp_sessions_active 2');
+      // Duration histogram: 60s
+      expect(metrics).toContain('mcp_session_duration_seconds_count 1');
+      // Idle histogram: 5s, reason=manual
+      expect(metrics).toContain('mcp_session_idle_seconds_count{reason="manual"} 1');
+    });
+
+    it('records expired status for expired close reason', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      recordSessionCreated();
+      recordSessionClosed(120_000, 30_000, 'expired');
+
+      const metrics = await reg.metrics();
+      expect(metrics).toContain('mcp_sessions_total{status="expired"} 1');
+      expect(metrics).toContain('mcp_sessions_active 0');
+      expect(metrics).toContain('mcp_session_idle_seconds_count{reason="expired"} 1');
+    });
+
+    it('records idle_timeout status for idle_timeout close reason', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      recordSessionCreated();
+      recordSessionClosed(60_000, 60_000, 'idle_timeout');
+
+      const metrics = await reg.metrics();
+      expect(metrics).toContain('mcp_sessions_total{status="idle_timeout"} 1');
+      expect(metrics).toContain('mcp_sessions_active 0');
+      expect(metrics).toContain('mcp_session_idle_seconds_count{reason="idle_timeout"} 1');
+    });
+
+    it('records duration in seconds (not ms)', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      // 5000ms = 5s
+      recordSessionCreated();
+      recordSessionClosed(5000, 1000, 'manual');
+
+      const metrics = await reg.metrics();
+      // 5s falls in bucket le=10
+      expect(metrics).toContain('mcp_session_duration_seconds_bucket{le="10"} 1');
+    });
+  });
+
+  describe('setSessionsActive (S-005)', () => {
+    it('does not throw when metrics are disabled', () => {
+      process.env.MCP_TRANSPORT = 'stdio';
+      initMetrics();
+      expect(() => setSessionsActive(42)).not.toThrow();
+    });
+
+    it('sets sessions_active gauge to exact value', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      setSessionsActive(10);
+      const metrics = await reg.metrics();
+      expect(metrics).toContain('mcp_sessions_active 10');
+
+      // Overwrite
+      setSessionsActive(25);
+      const metrics2 = await reg.metrics();
+      expect(metrics2).toContain('mcp_sessions_active 25');
+    });
+  });
+
+  describe('session metrics full lifecycle (S-005)', () => {
+    it('tracks create → active → close correctly across multiple sessions', async () => {
+      process.env.METRICS_ENABLED = '1';
+      const reg = initMetrics({ version: '1.0.0', defaultMetrics: false });
+
+      // Session A created
+      recordSessionCreated();
+      const m1 = await reg.metrics();
+      expect(m1).toContain('mcp_sessions_active 1');
+      expect(m1).toContain('mcp_sessions_total{status="opened"} 1');
+
+      // Session B created
+      recordSessionCreated();
+      const m2 = await reg.metrics();
+      expect(m2).toContain('mcp_sessions_active 2');
+      expect(m2).toContain('mcp_sessions_total{status="opened"} 2');
+
+      // Session A closed manually
+      recordSessionClosed(30_000, 5_000, 'manual');
+      const m3 = await reg.metrics();
+      expect(m3).toContain('mcp_sessions_active 1');
+      expect(m3).toContain('mcp_sessions_total{status="closed"} 1');
+
+      // Session B closed by idle timeout
+      recordSessionClosed(60_000, 30_000, 'idle_timeout');
+      const m4 = await reg.metrics();
+      expect(m4).toContain('mcp_sessions_active 0');
+      expect(m4).toContain('mcp_sessions_total{status="idle_timeout"} 1');
+
+      // Verify histogram counts
+      expect(m4).toContain('mcp_session_duration_seconds_count 2');
+      expect(m4).toContain('mcp_session_idle_seconds_count{reason="manual"} 1');
+      expect(m4).toContain('mcp_session_idle_seconds_count{reason="idle_timeout"} 1');
     });
   });
 });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionManager } from '../src/core/session-manager.js';
-import type { SessionManagerOptions, SessionInfo, CreateSessionOptions } from '../src/core/session-manager.js';
+import type { SessionManagerOptions, SessionInfo, CreateSessionOptions, SessionCloseReason } from '../src/core/session-manager.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────
 
@@ -382,5 +382,102 @@ describe('SessionManager — SessionInfo', () => {
     expect(infoAfter.ageMs).toBeGreaterThan(infoBefore.ageMs);
     // idleMs should reset to near 0 (much less than infoBefore.idleMs)
     expect(infoAfter.idleMs).toBeLessThan(infoBefore.idleMs);
+  });
+});
+
+// ─── S-005: Metrics callbacks ──────────────────────────────────────
+
+describe('SessionManager — S-005 metrics callbacks', () => {
+  it('should call onSessionCreate callback on create', () => {
+    const onCreate = vi.fn<() => void>();
+    const sm = new SessionManager({ onSessionCreate: onCreate });
+
+    sm.create({ remote: 'test:1' });
+    expect(onCreate).toHaveBeenCalledTimes(1);
+
+    sm.create({ remote: 'test:2' });
+    expect(onCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not call onSessionCreate when no callback provided', () => {
+    const sm = new SessionManager();
+    expect(() => sm.create({ remote: 'test' })).not.toThrow();
+  });
+
+  it('should call onSessionClose with manual reason on explicit close', async () => {
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = new SessionManager({ onSessionClose: onClose });
+    const session = sm.create({ remote: 'test' });
+
+    await sleep(100);
+    await sm.close(session.id);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const [durationMs, idleMs, reason] = onClose.mock.calls[0];
+    expect(durationMs).toBeGreaterThanOrEqual(0);
+    expect(idleMs).toBeGreaterThanOrEqual(0);
+    expect(reason).toBe('manual');
+  });
+
+  it('should call onSessionClose with expired reason on TTL prune', async () => {
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = createFastManager({ sessionTtlMs: 200, idleTimeoutMs: 99999, onSessionClose: onClose });
+    sm.create({ remote: 'a' });
+
+    await sleep(350);
+    await sm.prune();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][2]).toBe('expired');
+  });
+
+  it('should call onSessionClose with idle_timeout reason on idle prune', async () => {
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = createFastManager({ sessionTtlMs: 99999, idleTimeoutMs: 200, onSessionClose: onClose });
+    sm.create({ remote: 'a' });
+
+    await sleep(300);
+    await sm.prune();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][2]).toBe('idle_timeout');
+  });
+
+  it('should call onSessionClose with expired reason on per-session token expiry', async () => {
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = createFastManager({ sessionTtlMs: 99999, idleTimeoutMs: 99999, onSessionClose: onClose });
+    const session = sm.create({ remote: 'a' });
+
+    // Set per-session expiry to 100ms from now
+    sm.setSessionExpiry(session.id, Date.now() + 100);
+    await sleep(200);
+    await sm.prune();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][2]).toBe('expired');
+  });
+
+  it('should call both onSessionCreate and onSessionClose for full lifecycle', async () => {
+    const onCreate = vi.fn<() => void>();
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = new SessionManager({ onSessionCreate: onCreate, onSessionClose: onClose });
+
+    const session = sm.create({ remote: 'a' });
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await sleep(20);
+    await sm.close(session.id);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][2]).toBe('manual');
+  });
+
+  it('should not call onSessionClose when closing nonexistent session', async () => {
+    const onClose = vi.fn<(durationMs: number, idleMs: number, reason: SessionCloseReason) => void>();
+    const sm = new SessionManager({ onSessionClose: onClose });
+
+    const result = await sm.close('nonexistent');
+    expect(result).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `mcp_sessions_active` gauge — current active session count
- `mcp_sessions_total` counter — opened/closed/expired/idle_timeout
- `mcp_session_duration_seconds` histogram — session lifetime
- `mcp_session_idle_seconds` histogram — idle time before close
- SessionManager callbacks (onSessionCreate/onSessionClose) wired in AppContainer
- 17 new tests (989/989 total)

## Changes
- `src/core/metrics.ts` — 4 new metrics + 3 exported functions
- `src/core/session-manager.ts` — close reason param + lifecycle callbacks
- `src/core/app-container.ts` — wire metrics into SessionManager
- `tests/metrics.test.ts` — 10 tests
- `tests/session-manager.test.ts` — 7 tests

Closes S-005